### PR TITLE
coap: set gcoap_listener_t struct member with explicit naming

### DIFF
--- a/src/coap.c
+++ b/src/coap.c
@@ -46,9 +46,9 @@ static const coap_resource_t _resources[] = {
 };
 
 static gcoap_listener_t _listener = {
-    (coap_resource_t *)&_resources[0],
-    sizeof(_resources) / sizeof(_resources[0]),
-    NULL
+    .resources = (coap_resource_t *)&_resources[0],
+    .resources_len = sizeof(_resources) / sizeof(_resources[0]),
+    .next = NULL
 };
 
 static kernel_pid_t main_pid;


### PR DESCRIPTION
Using explicit member naming when initializing `gcoap_listener_t` is less error-prone. The current implementation fails when compiling with a newer RIOT, because the `gcoap_listener_t` has a new struct member.